### PR TITLE
Add DB indexed to improve performance

### DIFF
--- a/backend/resources/migrations/00007-index-get-all-surveys.down.sql
+++ b/backend/resources/migrations/00007-index-get-all-surveys.down.sql
@@ -1,0 +1,4 @@
+--;;
+DROP INDEX user_node_role_user_id;
+DROP INDEX users_flow_ids_user_id_admin;
+DROP INDEX nodes_type_instance;

--- a/backend/resources/migrations/00007-index-get-all-surveys.up.sql
+++ b/backend/resources/migrations/00007-index-get-all-surveys.up.sql
@@ -1,0 +1,4 @@
+--;;
+CREATE INDEX user_node_role_user_id ON user_node_role (user_id);
+CREATE INDEX users_flow_ids_user_id_admin ON users_flow_ids (user_id, super_admin);
+CREATE INDEX nodes_type_instance ON nodes (type, flow_instance);

--- a/backend/resources/sql/authz.sql
+++ b/backend/resources/sql/authz.sql
@@ -12,7 +12,8 @@ WITH
                 and ufi.user_id = :user-id
                 and ufi.super_admin = true
                 and n.flow_id = 0)
-select flow_id, flow_instance, name from nodes n WHERE n.type = 'SURVEY' AND n.full_path <@ ARRAY(select * FROM PERMS)
+select flow_id, flow_instance from nodes n WHERE n.type = 'SURVEY' AND n.full_path <@ ARRAY(select * FROM PERMS)
+  AND n.flow_instance IN (:v*:flow-instances)
 
 -- :name get-flow-ids-for-user-in-flow-instance :?
 select n.flow_id

--- a/backend/test/akvo_authorization/check_permissions_endpoint.clj
+++ b/backend/test/akvo_authorization/check_permissions_endpoint.clj
@@ -4,7 +4,7 @@
             [testit.core :as it :refer [=in=> fact =>]]))
 
 (deftest filters
-  (let [aliases (delay {"cool alias" "one"})
+  (let [aliases {"cool alias" "one"}
         a-survey {:instance_id "one" :survey_id "1" :some-random-key "anything"}
         other-survey {:instance_id "two" :survey_id "1"}
         allow-survey {:flow-instance "one" :flow-id 1 :other-key "anything else"}]

--- a/backend/test/akvo_authorization/compare_with_gae/compare_with_gae.clj
+++ b/backend/test/akvo_authorization/compare_with_gae/compare_with_gae.clj
@@ -104,10 +104,8 @@
                               (doall (filter-surveys all-survey flow_id)))
                   with-authz (set
                                (map :flow-id
-                                 (filter (fn [{:keys [flow-instance]}]
-                                           (= tenant flow-instance))
-                                   (akvo-authorization.authz/find-all-surveys
-                                     db email))))]
+                                 (akvo-authorization.authz/find-all-surveys
+                                   db email [tenant])))]
               (assoc
                 u
                 :with-flow with-flow


### PR DESCRIPTION
The main bottleneck was the main "select" of the permissions query as it
was using no index. The ltree index with the full path is useless here.

Adding a type+flow-instance index and passing to the DB query all the
flow-instances for all the queried forms.

Also, retrieving the minimum set of data required.